### PR TITLE
Refactor

### DIFF
--- a/src/tuf-client/api/constants.ts
+++ b/src/tuf-client/api/constants.ts
@@ -1,4 +1,0 @@
-export const ROOT = 'root';
-export const SNAPSHOT = 'snapshot';
-export const TARGETS = 'targets';
-export const TIMESTAMP = 'timestamp';

--- a/src/tuf-client/api/signed.test.ts
+++ b/src/tuf-client/api/signed.test.ts
@@ -1,16 +1,12 @@
-import { Signed } from './metadata';
+import { Signed, SignedOptions } from './signed';
 
 describe('Signed', () => {
-  class DummySigned extends Signed {
-    public toJSON() {
-      return {};
-    }
-  }
+  class DummySigned extends Signed {}
 
   describe('constructor', () => {
     describe('when called with no arguments', () => {
       it('constructs an object', () => {
-        const signed = new DummySigned();
+        const signed = new DummySigned({});
         expect(signed).toBeTruthy();
       });
     });
@@ -18,7 +14,7 @@ describe('Signed', () => {
     describe('when spec version is too short', () => {
       it('constructs an object', () => {
         expect(() => {
-          new DummySigned(1, '1');
+          new DummySigned({ specVersion: '1' });
         }).toThrow('Failed to parse specVersion');
       });
     });
@@ -26,7 +22,7 @@ describe('Signed', () => {
     describe('when spec version is too long', () => {
       it('constructs an object', () => {
         expect(() => {
-          new DummySigned(1, '1.0.0.0');
+          new DummySigned({ specVersion: '1.0.0.0' });
         }).toThrow('Failed to parse specVersion');
       });
     });
@@ -34,7 +30,7 @@ describe('Signed', () => {
     describe('when spec version includes non number', () => {
       it('constructs an object', () => {
         expect(() => {
-          new DummySigned(1, '1.b.c');
+          new DummySigned({ specVersion: '1.b.c' });
         }).toThrow('Failed to parse specVersion');
       });
     });
@@ -42,14 +38,19 @@ describe('Signed', () => {
     describe('when spec version is unsupported', () => {
       it('constructs an object', () => {
         expect(() => {
-          new DummySigned(1, '2.0.0');
+          new DummySigned({ specVersion: '2.0.0' });
         }).toThrow('Unsupported specVersion');
       });
     });
   });
 
   describe('equals', () => {
-    const subject = new DummySigned(1, '1.0.0', 1, {});
+    const opts: SignedOptions = {
+      version: 1,
+      specVersion: '1.0.0',
+      expires: 1,
+    };
+    const subject = new DummySigned(opts);
 
     describe('when other is not a Signed', () => {
       it('returns false', () => {
@@ -60,23 +61,23 @@ describe('Signed', () => {
 
     describe('when other is a Signed', () => {
       describe('when other is equal', () => {
+        const other = new DummySigned(opts);
         it('returns true', () => {
-          const other = new DummySigned(1, '1.0.0', 1, {});
           expect(subject.equals(other)).toBe(true);
         });
       });
 
       describe('when other is NOT equal', () => {
+        const other = new DummySigned({ ...opts, version: 2 });
         it('returns false', () => {
-          const other = new DummySigned(2, '1.0.0', 1, {});
           expect(subject.equals(other)).toBe(false);
         });
       });
 
       describe('when both with no arguments', () => {
+        const current = new DummySigned({});
+        const other = new DummySigned({});
         it('returns true', () => {
-          const current = new DummySigned();
-          const other = new DummySigned();
           expect(current.equals(other)).toBe(true);
         });
       });
@@ -84,7 +85,7 @@ describe('Signed', () => {
   });
 
   describe('isExpired', () => {
-    const subject = new DummySigned(1, '1.0.0', 100, {});
+    const subject = new DummySigned({ expires: 100 });
 
     describe('when reference time is not provided', () => {
       it('returns true', () => {
@@ -100,7 +101,7 @@ describe('Signed', () => {
 
     describe('when reference time is greater than the expiry time', () => {
       it('returns true', () => {
-        expect(subject.isExpired(new Date().getUTCMilliseconds())).toBe(true);
+        expect(subject.isExpired(new Date().getTime())).toBe(true);
       });
     });
   });

--- a/src/tuf-client/api/signed.ts
+++ b/src/tuf-client/api/signed.ts
@@ -1,0 +1,74 @@
+import util from 'util';
+
+const SPECIFICATION_VERSION = ['1', '20', '30'];
+
+export interface SignedOptions {
+  version?: number;
+  specVersion?: string;
+  expires?: number;
+  unrecognizedFields?: any;
+}
+
+export abstract class Signed {
+  public readonly specVersion: string;
+  public readonly expires: number;
+  public readonly version: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public unrecognizedFields: Record<string, any>;
+
+  constructor(options: SignedOptions) {
+    this.specVersion = options.specVersion || SPECIFICATION_VERSION.join('.');
+
+    const specList = this.specVersion.split('.');
+    if (
+      !(specList.length === 2 || specList.length === 3) ||
+      !specList.every((item) => isNumeric(item))
+    ) {
+      throw new Error('Failed to parse specVersion');
+    }
+
+    // major version must match
+    if (specList[0] != SPECIFICATION_VERSION[0]) {
+      throw new Error('Unsupported specVersion');
+    }
+
+    this.expires = options.expires || new Date().getTime();
+    this.version = options.version || 1;
+    this.unrecognizedFields = options.unrecognizedFields || {};
+  }
+
+  public equals(other: Signed): boolean {
+    if (!(other instanceof Signed)) {
+      return false;
+    }
+
+    return (
+      this.specVersion === other.specVersion &&
+      this.expires === other.expires &&
+      this.version === other.version &&
+      util.isDeepStrictEqual(this.unrecognizedFields, other.unrecognizedFields)
+    );
+  }
+
+  public isExpired(referenceTime?: number): boolean {
+    if (!referenceTime) {
+      referenceTime = new Date().getTime();
+    }
+    return referenceTime >= this.expires;
+  }
+
+  public static commonFieldsFromJSON(data: any): SignedOptions {
+    const { spec_version, expires, version, ...rest } = data;
+    const exp = new Date(expires).getTime();
+    return {
+      specVersion: spec_version,
+      expires: exp,
+      version,
+      unrecognizedFields: rest,
+    };
+  }
+}
+
+function isNumeric(str: string): boolean {
+  return /^\d+$/.test(str);
+}

--- a/src/tuf-client/ng-client/updater.ts
+++ b/src/tuf-client/ng-client/updater.ts
@@ -1,9 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { Root } from '../api/metadata';
-import { JSONValue } from '../utils/type';
-import {TrustedMetadataSet} from './internal/trustedMetadataSet'
-import {updaterConfig} from '../utils/config'
+import { updaterConfig } from '../utils/config';
+import { JSONObject } from '../utils/type';
+import { TrustedMetadataSet } from './internal/trustedMetadataSet';
 
 interface UodaterOptions {
   metadataDir: string;
@@ -17,8 +16,8 @@ export class Updater {
   private metadataBaseUrl: string;
   private targetDir?: string;
   private targetBaseUrl?: string;
-  private trustedSet?: TrustedMetadataSet; 
-  private config?: typeof updaterConfig; 
+  private trustedSet?: TrustedMetadataSet;
+  private config?: typeof updaterConfig;
 
   constructor(options: UodaterOptions) {
     const { metadataDir, metadataBaseUrl, targetDir, targetBaseUrl } = options;
@@ -31,20 +30,20 @@ export class Updater {
 
     const data = this.loadLocalMetadata();
     this.trustedSet = new TrustedMetadataSet(data);
-    this.config = updaterConfig; 
+    this.config = updaterConfig;
 
     // self._trusted_set = trusted_metadata_set.TrustedMetadataSet(data)
     // self._fetcher = fetcher or requests_fetcher.RequestsFetcher()
     // self.config = config or UpdaterConfig()
   }
 
-  private loadLocalMetadata(): JSONValue {
+  private loadLocalMetadata(): JSONObject {
     const filePath = path.join(this.dir, '1.root.json');
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
   }
 
-  private loadRoot () {
-    // Load remote root metadata. 
+  private loadRoot() {
+    // Load remote root metadata.
     // Sequentially load and persist on local disk every newer root metadata
     // version available on the remote.
   }

--- a/src/tuf-client/utils/type.ts
+++ b/src/tuf-client/utils/type.ts
@@ -1,7 +1,9 @@
+export type JSONObject = { [key: string]: JSONValue };
+
 export type JSONValue =
-  | string
-  | number
+  | null
   | boolean
-  | any
-  | { [x: string]: JSONValue }
-  | Array<JSONValue>;
+  | number
+  | string
+  | JSONValue[]
+  | JSONObject;


### PR DESCRIPTION
@ejahnGithub here are some refactoring ideas for your latest branch. We can discuss in detail when I'm back on Wednesday, but here are some highlights:

* Reworked the way the `fromJSON` stuff works a bit to make things a bit cleaner.
* Moved the `Signed` class into a separate module. I'd love to decompose more of the code in the "metadata.ts" but all of the circular references make it difficult. We can maybe use some interfaces to clean this up a bit more later.
* Ditched `lodash` in favor of the `isDeepStrictEqual` is the standard library
* Replaced calls to the `Date` object's `getUTCMilliseconds` with `getTime` -- take a look at the docs for the `Date` object, the distinction between these two is important.