### PR TITLE
support for ECDSA keys

### DIFF
--- a/examples/sigstore/root.json
+++ b/examples/sigstore/root.json
@@ -1,0 +1,130 @@
+{
+  "signatures": [
+    {
+      "keyid": "2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+      "sig": "30450221008a35d51da0f845301a5eac98ad0df00a934f59b709c1eaf81c86be734d9356f80220742942325599749800f52675f6efe124345980a2a636c0dc76f9caf9fc3123b0"
+    },
+    {
+      "keyid": "bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+      "sig": "3045022100ef9157ece2a09baec1eab80adfc00b04da20b1f9a0d1b47c5dabc4506719ef2c022074f72acd57398e4ddc8c2a5040df902961e9615dca48f3fbe38cbb506e500066"
+    },
+    {
+      "keyid": "eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+      "sig": "30450220420fdc9a09cd069b8b15fd8db9cedf7d0dee75871bd1cfee77c926d4120a770002210097553b5ad0d6b4a13902ed37509638bb63a9009f78230cd56c802909ffbfead7"
+    },
+    {
+      "keyid": "f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+      "sig": "304502202aaf32e66f90752f658672b085ecfe45cc1ad31ee6cf5c9ad05f3267685f8d88022100b5df02acdaa371123db9d7a42219553fe079b230b168833e951be7ee56ded347"
+    },
+    {
+      "keyid": "f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209",
+      "sig": "304402205d420c7d05c58980c1c9f7d221f53b5334aae27a447d2a91c2ceddd685269749022039ec83e51f8e1779d7f0142dfa4a5bbecfe327fc0b91b7416090fea2416fd53a"
+    }
+  ],
+  "signed": {
+    "_type": "root",
+    "consistent_snapshot": false,
+    "expires": "2021-12-18T13:28:12.99008-06:00",
+    "keys": {
+      "2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ecdsa-sha2-nistp256",
+        "keyval": {
+          "public": "04cbc5cab2684160323c25cd06c3307178a6b1d1c9b949328453ae473c5ba7527e35b13f298b41633382241f3fd8526c262d43b45adee5c618fa0642c82b8a9803"
+        },
+        "scheme": "ecdsa-sha2-nistp256"
+      },
+      "bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ecdsa-sha2-nistp256",
+        "keyval": {
+          "public": "04a71aacd835dc170ba6db3fa33a1a33dee751d4f8b0217b805b9bd3242921ee93672fdcfd840576c5bb0dc0ed815edf394c1ee48c2b5e02485e59bfc512f3adc7"
+        },
+        "scheme": "ecdsa-sha2-nistp256"
+      },
+      "eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ecdsa-sha2-nistp256",
+        "keyval": {
+          "public": "04117b33dd265715bf23315e368faa499728db8d1f0a377070a1c7b1aba2cc21be6ab1628e42f2cdd7a35479f2dce07b303a8ba646c55569a8d2a504ba7e86e447"
+        },
+        "scheme": "ecdsa-sha2-nistp256"
+      },
+      "f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ecdsa-sha2-nistp256",
+        "keyval": {
+          "public": "04cc1cd53a61c23e88cc54b488dfae168a257c34fac3e88811c55962b24cffbfecb724447999c54670e365883716302e49da57c79a33cd3e16f81fbc66f0bcdf48"
+        },
+        "scheme": "ecdsa-sha2-nistp256"
+      },
+      "f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209": {
+        "keyid_hash_algorithms": [
+          "sha256",
+          "sha512"
+        ],
+        "keytype": "ecdsa-sha2-nistp256",
+        "keyval": {
+          "public": "048a78a44ac01099890d787e5e62afc29c8ccb69a70ec6549a6b04033b0a8acbfb42ab1ab9c713d225cdb52b858886cf46c8e90a7f3b9e6371882f370c259e1c5b"
+        },
+        "scheme": "ecdsa-sha2-nistp256"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+          "bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+          "eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+          "f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+          "f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209"
+        ],
+        "threshold": 3
+      },
+      "snapshot": {
+        "keyids": [
+          "2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+          "bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+          "eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+          "f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+          "f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209"
+        ],
+        "threshold": 3
+      },
+      "targets": {
+        "keyids": [
+          "2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+          "bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+          "eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+          "f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+          "f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209"
+        ],
+        "threshold": 3
+      },
+      "timestamp": {
+        "keyids": [
+          "2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+          "bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+          "eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+          "f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+          "f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209"
+        ],
+        "threshold": 3
+      }
+    },
+    "spec_version": "1.0",
+    "version": 1
+  }
+}

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -1,56 +1,107 @@
 import canonicalize from 'canonicalize';
 import crypto from 'crypto';
 import * as fs from 'fs';
-import { ed25519 } from './tuf-client/utils/key';
+import { ecdsa, ed25519 } from './tuf-client/utils/key';
 
-describe('sample verification', () => {
-  const root = JSON.parse(fs.readFileSync('./examples/root.json').toString());
-  const timestamp = JSON.parse(
-    fs.readFileSync('./examples/timestamp.json').toString()
+describe('sigstore TUF', () => {
+  const root = JSON.parse(
+    fs.readFileSync('./examples/sigstore/root.json').toString()
   );
 
-  describe('when the signature is valid', () => {
+  describe('root verification', () => {
     it('should verify', () => {
-      const signature = timestamp.signatures[0];
+      const signature = root.signatures[0];
       const sig = signature.sig;
 
       const key = root.signed.keys[signature.keyid].keyval.public;
-      const publicKey = ed25519.fromHex(key);
+      const publicKey = ecdsa.fromHex(key);
 
-      const signedDataCanonical = canonicalize(timestamp.signed) || '';
-      const te = new TextEncoder();
-      const data = te.encode(signedDataCanonical);
+      const canonicalData = canonicalize(root.signed) || '';
 
       const result = crypto.verify(
         undefined,
-        data,
+        Buffer.from(canonicalData, 'utf8'),
         publicKey,
         Buffer.from(sig, 'hex')
       );
+
       expect(result).toBe(true);
     });
   });
+});
 
-  describe('when the signature is invalid', () => {
-    it('should NOT verify', () => {
-      const signature = timestamp.signatures[0];
-      const sig = signature.sig;
+describe('python TUF sample', () => {
+  describe('verify timestamp meta from root ', () => {
+    const root = JSON.parse(fs.readFileSync('./examples/root.json').toString());
+    const timestamp = JSON.parse(
+      fs.readFileSync('./examples/timestamp.json').toString()
+    );
 
-      const key = root.signed.keys[signature.keyid].keyval.public;
-      const publicKey = ed25519.fromHex(key);
+    describe('when the signature is valid', () => {
+      it('should verify', () => {
+        const signature = timestamp.signatures[0];
+        const sig = signature.sig;
 
-      const signedDataCanonical =
-        canonicalize({ ...timestamp.signed, foo: 'bar' }) || '';
-      const te = new TextEncoder();
-      const data = te.encode(signedDataCanonical);
+        const key = root.signed.keys[signature.keyid].keyval.public;
+        const publicKey = ed25519.fromHex(key);
 
-      const result = crypto.verify(
-        undefined,
-        data,
-        publicKey,
-        Buffer.from(sig, 'hex')
-      );
-      expect(result).toBe(false);
+        const canonicalData = canonicalize(timestamp.signed) || '';
+
+        const result = crypto.verify(
+          undefined,
+          Buffer.from(canonicalData, 'utf8'),
+          publicKey,
+          Buffer.from(sig, 'hex')
+        );
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('when the signature is invalid', () => {
+      it('should NOT verify', () => {
+        const signature = timestamp.signatures[0];
+        const sig = signature.sig;
+
+        const key = root.signed.keys[signature.keyid].keyval.public;
+        const publicKey = ed25519.fromHex(key);
+
+        const canonicalData =
+          canonicalize({ ...timestamp.signed, foo: 'bar' }) || '';
+
+        const result = crypto.verify(
+          undefined,
+          Buffer.from(canonicalData),
+          publicKey,
+          Buffer.from(sig, 'hex')
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('verifying root w/ RSA key', () => {
+      xit('should verify', () => {
+        const signature = root.signatures[0];
+        const sig = signature.sig;
+
+        const key = root.signed.keys[signature.keyid].keyval.public;
+        const publicKey = crypto.createPublicKey(key);
+
+        const canonicalData = canonicalize(root.signed) || '';
+
+        const result = crypto.verify(
+          'SHA256',
+          Buffer.from(canonicalData, 'utf8'),
+          // {
+          //   key: key,
+          //   format: 'pem',
+          //   padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+          //   saltLength: crypto.constants.RSA_PSS_SALTLEN_AUTO,
+          // },
+          publicKey,
+          Buffer.from(sig, 'hex')
+        );
+        expect(result).toBe(true);
+      });
     });
   });
 });

--- a/src/tuf-client/utils/key.test.ts
+++ b/src/tuf-client/utils/key.test.ts
@@ -1,0 +1,52 @@
+import { encodeOIDString, ecdsa, ed25519 } from './key';
+
+describe('encodeOIDString', () => {
+  it('encodes OIDs propertly', () => {
+    let r = encodeOIDString('1.3.6.1.4.1.311.21.20');
+    expect(r).toEqual(Buffer.from('06092b0601040182371514', 'hex'));
+
+    r = encodeOIDString('1.2.840.10045.2.1');
+    expect(r).toEqual(Buffer.from('06072a8648ce3d0201', 'hex'));
+
+    r = encodeOIDString('1.2.840.10045.3.1.7');
+    expect(r).toEqual(Buffer.from('06082a8648ce3d030107', 'hex'));
+
+    r = encodeOIDString('1.3.6.1.4.1.57264.1.3');
+    expect(r).toEqual(Buffer.from('060a2b0601040183bf300103', 'hex'));
+
+    r = encodeOIDString('2.3.21925.1');
+    expect(r).toEqual(Buffer.from('06055381ab2501', 'hex'));
+  });
+});
+
+describe('ed25519', () => {
+  const bit =
+    'edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd';
+  it('encodes keys properly', () => {
+    const pem = ed25519.fromHex(bit);
+    expect(pem.type).toEqual('public');
+    expect(pem.asymmetricKeyType).toEqual('ed25519');
+
+    // Only exists in Node 16+
+    if (pem.asymmetricKeyDetails) {
+      expect(pem.asymmetricKeyDetails).toEqual({});
+    }
+  });
+});
+
+describe('ecdsa', () => {
+  const bit =
+    '04cbc5cab2684160323c25cd06c3307178a6b1d1c9b949328453ae473c5ba7527e35b13f298b41633382241f3fd8526c262d43b45adee5c618fa0642c82b8a9803';
+  describe('fromHex', () => {
+    it('encodes a public key', () => {
+      const pem = ecdsa.fromHex(bit);
+      expect(pem.type).toEqual('public');
+      expect(pem.asymmetricKeyType).toEqual('ec');
+
+      // Only exists in Node 16+
+      if (pem.asymmetricKeyDetails) {
+        expect(pem.asymmetricKeyDetails).toEqual({ namedCurve: 'prime256v1' });
+      }
+    });
+  });
+});

--- a/src/tuf-client/utils/key.ts
+++ b/src/tuf-client/utils/key.ts
@@ -1,32 +1,39 @@
 import crypto from 'crypto';
 
+const ANS1_TAG_OID = 0x06;
+const ASN1_TAG_SEQUENCE = 0x30;
+const ANS1_TAG_BIT_STRING = 0x03;
+const NULL_BYTE = 0x00;
+
+const OID_EDDSA = '1.3.101.112';
+const OID_EC_PUBLIC_KEY = '1.2.840.10045.2.1';
+const OID_EC_CURVE_P256V1 = '1.2.840.10045.3.1.7';
+
 export const ed25519 = {
   // Translates a hex key into a crypto KeyObject
   // https://keygen.sh/blog/how-to-use-hexadecimal-ed25519-keys-in-node/
   fromHex: (hex: string): crypto.KeyObject => {
     const key = Buffer.from(hex, 'hex');
-
-    // Ed25519's OID
-    const oid = Buffer.from([0x06, 0x03, 0x2b, 0x65, 0x70]);
+    const oid = encodeOIDString(OID_EDDSA);
 
     // Create a byte sequence containing the OID and key
     const elements = Buffer.concat([
       Buffer.concat([
-        Buffer.from([0x30]), // Sequence tag
+        Buffer.from([ASN1_TAG_SEQUENCE]),
         Buffer.from([oid.length]),
         oid,
       ]),
       Buffer.concat([
-        Buffer.from([0x03]), // Bit tag
+        Buffer.from([ANS1_TAG_BIT_STRING]),
         Buffer.from([key.length + 1]),
-        Buffer.from([0x00]), // Zero bit
+        Buffer.from([NULL_BYTE]),
         key,
       ]),
     ]);
 
     // Wrap up by creating a sequence of elements
     const der = Buffer.concat([
-      Buffer.from([0x30]), // Sequence tag
+      Buffer.from([ASN1_TAG_SEQUENCE]),
       Buffer.from([elements.length]),
       elements,
     ]);
@@ -39,6 +46,66 @@ export const ed25519 = {
   },
 };
 
-export const rsa = {};
+export const ecdsa = {
+  fromHex: (hex: string): crypto.KeyObject => {
+    const key = Buffer.from(hex, 'hex');
+    const bitString = Buffer.concat([
+      Buffer.from([ANS1_TAG_BIT_STRING]),
+      Buffer.from([key.length + 1]),
+      Buffer.from([NULL_BYTE]),
+      key,
+    ]);
 
-export const ecdsa = {};
+    const oids = Buffer.concat([
+      encodeOIDString(OID_EC_PUBLIC_KEY),
+      encodeOIDString(OID_EC_CURVE_P256V1),
+    ]);
+
+    const oidSequence = Buffer.concat([
+      Buffer.from([ASN1_TAG_SEQUENCE]),
+      Buffer.from([oids.length]),
+      oids,
+    ]);
+
+    // Wrap up by creating a sequence of elements
+    const der = Buffer.concat([
+      Buffer.from([ASN1_TAG_SEQUENCE]),
+      Buffer.from([oidSequence.length + bitString.length]),
+      oidSequence,
+      bitString,
+    ]);
+
+    return crypto.createPublicKey({
+      key: der,
+      format: 'der',
+      type: 'spki',
+    });
+  },
+};
+
+export function encodeOIDString(oid: string): Buffer {
+  const parts = oid.split('.');
+
+  // The first two subidentifiers are encoded into the first byte
+  const first = parseInt(parts[0], 10) * 40 + parseInt(parts[1], 10);
+
+  let rest: number[] = [];
+  parts.slice(2).forEach((part) => {
+    const bytes = encodeVariableLengthInteger(parseInt(part, 10));
+    rest.push(...bytes);
+  });
+
+  const der = Buffer.from([first, ...rest]);
+  return Buffer.from([ANS1_TAG_OID, der.length, ...der]);
+}
+
+function encodeVariableLengthInteger(value: number): number[] {
+  const bytes: number[] = [];
+  let mask = 0x00;
+  while (value > 0) {
+    bytes.unshift((value & 0x7f) | mask);
+    value >>= 7;
+    mask = 0x80;
+  }
+  return bytes;
+}


### PR DESCRIPTION
Add support for decoding ECDSA keys so that we can validate signatures in the Sigstore TUF root.