### PR TITLE
clean-up public key handling

### DIFF
--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -1,7 +1,7 @@
 import canonicalize from 'canonicalize';
 import crypto from 'crypto';
 import * as fs from 'fs';
-import { ecdsa, ed25519 } from './tuf-client/utils/key';
+import { getPublicKey } from './tuf-client/utils/key';
 
 describe('sigstore TUF', () => {
   const root = JSON.parse(
@@ -14,7 +14,11 @@ describe('sigstore TUF', () => {
       const sig = signature.sig;
 
       const key = root.signed.keys[signature.keyid].keyval.public;
-      const publicKey = ecdsa.fromHex(key);
+      const publicKey = getPublicKey({
+        keyType: 'ecdsa',
+        scheme: 'ecdsa',
+        keyVal: key,
+      });
 
       const canonicalData = canonicalize(root.signed) || '';
 
@@ -43,7 +47,11 @@ describe('python TUF sample', () => {
         const sig = signature.sig;
 
         const key = root.signed.keys[signature.keyid].keyval.public;
-        const publicKey = ed25519.fromHex(key);
+        const publicKey = getPublicKey({
+          keyType: 'ed25519',
+          scheme: 'ed25519',
+          keyVal: key,
+        });
 
         const canonicalData = canonicalize(timestamp.signed) || '';
 
@@ -63,7 +71,11 @@ describe('python TUF sample', () => {
         const sig = signature.sig;
 
         const key = root.signed.keys[signature.keyid].keyval.public;
-        const publicKey = ed25519.fromHex(key);
+        const publicKey = getPublicKey({
+          keyType: 'ed25519',
+          scheme: 'ed25519',
+          keyVal: key,
+        });
 
         const canonicalData =
           canonicalize({ ...timestamp.signed, foo: 'bar' }) || '';

--- a/src/tuf-client/api/error.ts
+++ b/src/tuf-client/api/error.ts
@@ -11,3 +11,7 @@ export class EqualVersionNumberError extends RepositoryError {}
 export class ExpiredMetadataError extends RepositoryError {}
 
 export class LengthOrHashMismatchError extends RepositoryError {}
+
+export class CryptoError extends Error {}
+
+export class UnsupportedAlgorithmError extends CryptoError {}

--- a/src/tuf-client/api/key.test.ts
+++ b/src/tuf-client/api/key.test.ts
@@ -100,7 +100,7 @@ describe('Key', () => {
       it('throws an error', () => {
         expect(() => {
           badKey.verifySignature(metadata);
-        }).toThrowError(UnsignedMetadataError);
+        }).toThrowError();
       });
     });
 

--- a/src/tuf-client/utils/key.test.ts
+++ b/src/tuf-client/utils/key.test.ts
@@ -1,52 +1,42 @@
-import { encodeOIDString, ecdsa, ed25519 } from './key';
+import { getPublicKey } from './key';
 
-describe('encodeOIDString', () => {
-  it('encodes OIDs propertly', () => {
-    let r = encodeOIDString('1.3.6.1.4.1.311.21.20');
-    expect(r).toEqual(Buffer.from('06092b0601040182371514', 'hex'));
+describe('getPublicKey', () => {
+  describe('when key is ed25519', () => {
+    const type = 'ed25519';
+    const scheme = 'ed25519';
+    const bit =
+      'edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd';
 
-    r = encodeOIDString('1.2.840.10045.2.1');
-    expect(r).toEqual(Buffer.from('06072a8648ce3d0201', 'hex'));
-
-    r = encodeOIDString('1.2.840.10045.3.1.7');
-    expect(r).toEqual(Buffer.from('06082a8648ce3d030107', 'hex'));
-
-    r = encodeOIDString('1.3.6.1.4.1.57264.1.3');
-    expect(r).toEqual(Buffer.from('060a2b0601040183bf300103', 'hex'));
-
-    r = encodeOIDString('2.3.21925.1');
-    expect(r).toEqual(Buffer.from('06055381ab2501', 'hex'));
-  });
-});
-
-describe('ed25519', () => {
-  const bit =
-    'edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd';
-  it('encodes keys properly', () => {
-    const pem = ed25519.fromHex(bit);
-    expect(pem.type).toEqual('public');
-    expect(pem.asymmetricKeyType).toEqual('ed25519');
-
-    // Only exists in Node 16+
-    if (pem.asymmetricKeyDetails) {
-      expect(pem.asymmetricKeyDetails).toEqual({});
-    }
-  });
-});
-
-describe('ecdsa', () => {
-  const bit =
-    '04cbc5cab2684160323c25cd06c3307178a6b1d1c9b949328453ae473c5ba7527e35b13f298b41633382241f3fd8526c262d43b45adee5c618fa0642c82b8a9803';
-  describe('fromHex', () => {
-    it('encodes a public key', () => {
-      const pem = ecdsa.fromHex(bit);
+    it('encodes keys properly', () => {
+      const pem = getPublicKey({ keyType: type, scheme, keyVal: bit });
       expect(pem.type).toEqual('public');
-      expect(pem.asymmetricKeyType).toEqual('ec');
+      expect(pem.asymmetricKeyType).toEqual('ed25519');
 
       // Only exists in Node 16+
       if (pem.asymmetricKeyDetails) {
-        expect(pem.asymmetricKeyDetails).toEqual({ namedCurve: 'prime256v1' });
+        expect(pem.asymmetricKeyDetails).toEqual({});
       }
+    });
+  });
+
+  describe('when key is ecdsa', () => {
+    const type = 'ecdsa-sha2-nistp256';
+    const scheme = 'ecdsa-sha2-nistp256';
+    const bit =
+      '04cbc5cab2684160323c25cd06c3307178a6b1d1c9b949328453ae473c5ba7527e35b13f298b41633382241f3fd8526c262d43b45adee5c618fa0642c82b8a9803';
+    describe('fromHex', () => {
+      it('encodes a public key', () => {
+        const pem = getPublicKey({ keyType: type, scheme, keyVal: bit });
+        expect(pem.type).toEqual('public');
+        expect(pem.asymmetricKeyType).toEqual('ec');
+
+        // Only exists in Node 16+
+        if (pem.asymmetricKeyDetails) {
+          expect(pem.asymmetricKeyDetails).toEqual({
+            namedCurve: 'prime256v1',
+          });
+        }
+      });
     });
   });
 });

--- a/src/tuf-client/utils/oid.test.ts
+++ b/src/tuf-client/utils/oid.test.ts
@@ -1,0 +1,18 @@
+import { encodeOIDString } from './oid';
+
+describe('encodeOIDString', () => {
+  const testCases = [
+    { oid: '1.3.6.1.4.1.311.21.20', expected: '06092b0601040182371514' },
+    { oid: '1.2.840.10045.2.1', expected: '06072a8648ce3d0201' },
+    { oid: '1.2.840.10045.3.1.7', expected: '06082a8648ce3d030107' },
+    { oid: '1.3.6.1.4.1.57264.1.3', expected: '060a2b0601040183bf300103' },
+    { oid: '2.3.21925.1', expected: '06055381ab2501' },
+  ];
+
+  it('encodes OIDs propertly', () => {
+    testCases.forEach(({ oid, expected }) => {
+      const r = encodeOIDString(oid);
+      expect(r).toEqual(Buffer.from(expected, 'hex'));
+    });
+  });
+});

--- a/src/tuf-client/utils/oid.ts
+++ b/src/tuf-client/utils/oid.ts
@@ -1,0 +1,28 @@
+const ANS1_TAG_OID = 0x06;
+
+export function encodeOIDString(oid: string): Buffer {
+  const parts = oid.split('.');
+
+  // The first two subidentifiers are encoded into the first byte
+  const first = parseInt(parts[0], 10) * 40 + parseInt(parts[1], 10);
+
+  const rest: number[] = [];
+  parts.slice(2).forEach((part) => {
+    const bytes = encodeVariableLengthInteger(parseInt(part, 10));
+    rest.push(...bytes);
+  });
+
+  const der = Buffer.from([first, ...rest]);
+  return Buffer.from([ANS1_TAG_OID, der.length, ...der]);
+}
+
+function encodeVariableLengthInteger(value: number): number[] {
+  const bytes: number[] = [];
+  let mask = 0x00;
+  while (value > 0) {
+    bytes.unshift((value & 0x7f) | mask);
+    value >>= 7;
+    mask = 0x80;
+  }
+  return bytes;
+}

--- a/src/tuf-client/utils/signer.ts
+++ b/src/tuf-client/utils/signer.ts
@@ -1,41 +1,14 @@
 import canonicalize from 'canonicalize';
 import crypto from 'crypto';
-import { ed25519, ecdsa } from './key';
 import { JSONObject } from '../api/types';
 
 export const verifySignature = (
-  keyType: string,
   metaDataSignedData: JSONObject,
-  signature: string,
-  key: string
+  key: crypto.KeyObject,
+  signature: string
 ): boolean => {
   const signedDataCanonical = canonicalize(metaDataSignedData) || '';
   const data = new TextEncoder().encode(signedDataCanonical);
 
-  if (keyType === 'ed25519') {
-    const publicKey = ed25519.fromHex(key);
-
-    const result = crypto.verify(
-      undefined,
-      data,
-      publicKey,
-      Buffer.from(signature, 'hex')
-    );
-
-    return result;
-  } else if (keyType === 'ecdsa-sha2-nistp256') {
-    const publicKey = ecdsa.fromHex(key);
-    const result = crypto.verify(
-      undefined,
-      data,
-      publicKey,
-      Buffer.from(signature, 'hex')
-    );
-
-    console.log('verify ', result);
-
-    return result;
-  }
-
-  return false;
+  return crypto.verify(undefined, data, key, Buffer.from(signature, 'hex'));
 };


### PR DESCRIPTION
Refactors the way we handle public keys to make things a bit cleaner.

Introduces a new `getPublicKey` function which encapsulates all of the logic to translate key material into a usable `KeyObject`. This will handle both PEM and hex-encoded keys for the various algorithms we need to support.