### PR TITLE
implement json canonicalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "canonicalize": "^1.0.8",
         "make-fetch-happen": "^10.2.1",
         "minimatch": "^5.1.0"
       },
@@ -2108,11 +2107,6 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
-    },
-    "node_modules/canonicalize": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7116,11 +7110,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001383.tgz",
       "integrity": "sha512-swMpEoTp5vDoGBZsYZX7L7nXHe6dsHxi9o6/LKf/f0LukVtnrxly5GVb/fWdCDTqi/yw6Km6tiJ0pmBacm0gbg==",
       "dev": true
-    },
-    "canonicalize": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "canonicalize": "^1.0.8",
     "make-fetch-happen": "^10.2.1",
     "minimatch": "^5.1.0"
   }

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -1,6 +1,6 @@
-import canonicalize from 'canonicalize';
 import crypto from 'crypto';
 import * as fs from 'fs';
+import { canonicalize } from './utils/json';
 import { getPublicKey } from './utils/key';
 
 describe('sigstore TUF', () => {
@@ -24,7 +24,7 @@ describe('sigstore TUF', () => {
 
       const result = crypto.verify(
         undefined,
-        Buffer.from(canonicalData, 'utf8'),
+        canonicalData,
         publicKey,
         Buffer.from(sig, 'hex')
       );
@@ -57,7 +57,7 @@ describe('python TUF sample', () => {
 
         const result = crypto.verify(
           undefined,
-          Buffer.from(canonicalData, 'utf8'),
+          canonicalData,
           publicKey,
           Buffer.from(sig, 'hex')
         );
@@ -82,7 +82,7 @@ describe('python TUF sample', () => {
 
         const result = crypto.verify(
           undefined,
-          Buffer.from(canonicalData),
+          canonicalData,
           publicKey,
           Buffer.from(sig, 'hex')
         );
@@ -91,25 +91,21 @@ describe('python TUF sample', () => {
     });
 
     describe('verifying root w/ RSA key', () => {
-      xit('should verify', () => {
+      it('should verify', () => {
         const signature = root.signatures[0];
         const sig = signature.sig;
 
         const key = root.signed.keys[signature.keyid].keyval.public;
-        const publicKey = crypto.createPublicKey(key);
 
         const canonicalData = canonicalize(root.signed) || '';
 
         const result = crypto.verify(
-          'SHA256',
-          Buffer.from(canonicalData, 'utf8'),
-          // {
-          //   key: key,
-          //   format: 'pem',
-          //   padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
-          //   saltLength: crypto.constants.RSA_PSS_SALTLEN_AUTO,
-          // },
-          publicKey,
+          undefined,
+          canonicalData,
+          {
+            key: key,
+            padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+          },
           Buffer.from(sig, 'hex')
         );
         expect(result).toBe(true);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * as config from './config';
 export * as guard from './guard';
+export * as json from './json';
 export * as signer from './signer';

--- a/src/utils/json.test.ts
+++ b/src/utils/json.test.ts
@@ -1,0 +1,10 @@
+import { canonicalize } from './json';
+
+describe('canonicalize', () => {
+  it('should canonicalize a string', () => {
+    const json = { z: 'zee', a: 'aye', newline: 'foo\nbar' };
+    expect(canonicalize(json)).toEqual(
+      Buffer.from('{"a":"aye","newline":"foo\nbar","z":"zee"}')
+    );
+  });
+});

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,58 @@
+const QUOTATION_MARK = Buffer.from('"');
+const COMMA = Buffer.from(',');
+const COLON = Buffer.from(':');
+const LEFT_SQUARE_BRACKET = Buffer.from('[');
+const RIGHT_SQUARE_BRACKET = Buffer.from(']');
+const LEFT_CURLY_BRACKET = Buffer.from('{');
+const RIGHT_CURLY_BRACKET = Buffer.from('}');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function canonicalize(object: any): Buffer {
+  let buffer = Buffer.from('');
+
+  if (object === null || typeof object !== 'object' || object.toJSON != null) {
+    // Primitives or toJSONable objects
+    if (typeof object === 'string') {
+      buffer = Buffer.concat([
+        buffer,
+        QUOTATION_MARK,
+        Buffer.from(object),
+        QUOTATION_MARK,
+      ]);
+    } else {
+      buffer = Buffer.concat([buffer, Buffer.from(JSON.stringify(object))]);
+    }
+  } else if (Array.isArray(object)) {
+    // Array - maintain element order
+    buffer = Buffer.concat([buffer, LEFT_SQUARE_BRACKET]);
+    let first = true;
+    object.forEach((element) => {
+      if (!first) {
+        buffer = Buffer.concat([buffer, COMMA]);
+      }
+      first = false;
+      // recursive call
+      buffer = Buffer.concat([buffer, canonicalize(element)]);
+    });
+    buffer = Buffer.concat([buffer, RIGHT_SQUARE_BRACKET]);
+  } else {
+    // Object - Sort properties before serializing
+    buffer = Buffer.concat([buffer, LEFT_CURLY_BRACKET]);
+    let first = true;
+    Object.keys(object)
+      .sort()
+      .forEach((property) => {
+        if (!first) {
+          buffer = Buffer.concat([buffer, COMMA]);
+        }
+        first = false;
+        buffer = Buffer.concat([buffer, Buffer.from(JSON.stringify(property))]);
+        buffer = Buffer.concat([buffer, COLON]);
+        // recursive call
+        buffer = Buffer.concat([buffer, canonicalize(object[property])]);
+      });
+    buffer = Buffer.concat([buffer, RIGHT_CURLY_BRACKET]);
+  }
+
+  return buffer;
+}

--- a/src/utils/signer.ts
+++ b/src/utils/signer.ts
@@ -1,14 +1,18 @@
-import canonicalize from 'canonicalize';
 import crypto from 'crypto';
 import { JSONObject } from '../models';
+import { canonicalize } from './json';
 
 export const verifySignature = (
   metaDataSignedData: JSONObject,
   key: crypto.KeyObject,
   signature: string
 ): boolean => {
-  const signedDataCanonical = canonicalize(metaDataSignedData) || '';
-  const data = new TextEncoder().encode(signedDataCanonical);
+  const canonicalData = canonicalize(metaDataSignedData) || '';
 
-  return crypto.verify(undefined, data, key, Buffer.from(signature, 'hex'));
+  return crypto.verify(
+    undefined,
+    canonicalData,
+    key,
+    Buffer.from(signature, 'hex')
+  );
 };


### PR DESCRIPTION
Ditch the `canonicalize` package in favor of a local implementation of the JSON canonicalization logic which better matches the TUF spec