### PR TITLE
add support for RSA keys

### DIFF
--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -95,17 +95,19 @@ describe('python TUF sample', () => {
         const signature = root.signatures[0];
         const sig = signature.sig;
 
-        const key = root.signed.keys[signature.keyid].keyval.public;
+        const key = root.signed.keys[signature.keyid];
+        const publicKey = getPublicKey({
+          keyType: key.keytype,
+          scheme: key.scheme,
+          keyVal: key.keyval.public,
+        });
 
         const canonicalData = canonicalize(root.signed) || '';
 
         const result = crypto.verify(
           undefined,
           canonicalData,
-          {
-            key: key,
-            padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
-          },
+          publicKey,
           Buffer.from(sig, 'hex')
         );
         expect(result).toBe(true);

--- a/src/utils/key.test.ts
+++ b/src/utils/key.test.ts
@@ -8,13 +8,14 @@ describe('getPublicKey', () => {
       'edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd';
 
     it('encodes keys properly', () => {
-      const pem = getPublicKey({ keyType: type, scheme, keyVal: bit });
-      expect(pem.type).toEqual('public');
-      expect(pem.asymmetricKeyType).toEqual('ed25519');
+      const publicKey = getPublicKey({ keyType: type, scheme, keyVal: bit });
+
+      expect(publicKey.key.type).toEqual('public');
+      expect(publicKey.key.asymmetricKeyType).toEqual('ed25519');
 
       // Only exists in Node 16+
-      if (pem.asymmetricKeyDetails) {
-        expect(pem.asymmetricKeyDetails).toEqual({});
+      if (publicKey.key.asymmetricKeyDetails) {
+        expect(publicKey.key.asymmetricKeyDetails).toEqual({});
       }
     });
   });
@@ -26,13 +27,13 @@ describe('getPublicKey', () => {
       '04cbc5cab2684160323c25cd06c3307178a6b1d1c9b949328453ae473c5ba7527e35b13f298b41633382241f3fd8526c262d43b45adee5c618fa0642c82b8a9803';
     describe('fromHex', () => {
       it('encodes a public key', () => {
-        const pem = getPublicKey({ keyType: type, scheme, keyVal: bit });
-        expect(pem.type).toEqual('public');
-        expect(pem.asymmetricKeyType).toEqual('ec');
+        const publicKey = getPublicKey({ keyType: type, scheme, keyVal: bit });
+        expect(publicKey.key.type).toEqual('public');
+        expect(publicKey.key.asymmetricKeyType).toEqual('ec');
 
         // Only exists in Node 16+
-        if (pem.asymmetricKeyDetails) {
-          expect(pem.asymmetricKeyDetails).toEqual({
+        if (publicKey.key.asymmetricKeyDetails) {
+          expect(publicKey.key.asymmetricKeyDetails).toEqual({
             namedCurve: 'prime256v1',
           });
         }

--- a/src/utils/signer.ts
+++ b/src/utils/signer.ts
@@ -4,7 +4,7 @@ import { canonicalize } from './json';
 
 export const verifySignature = (
   metaDataSignedData: JSONObject,
-  key: crypto.KeyObject,
+  key: crypto.VerifyKeyObjectInput,
   signature: string
 ): boolean => {
   const canonicalData = canonicalize(metaDataSignedData) || '';


### PR DESCRIPTION
Updates the `getPublicKey` utility function to properly handle RSA keys in addition to ED25519 and ECDSA.

Changes the return type of `getPublicKey` from `KeyObject` to `VerifyKeyObjectInput` so that we can convey the padding options necessary for using the RSA key.