### PR TITLE
add withTempFile utility function

### DIFF
--- a/src/__tests__/utils/tmpfile.test.ts
+++ b/src/__tests__/utils/tmpfile.test.ts
@@ -1,0 +1,13 @@
+import { withTempFile } from '../../utils/tmpfile';
+
+describe('withTempFile', () => {
+  it('creates a temporary file', async () => {
+    const file = await withTempFile(async (tmpFile) => {
+      expect(tmpFile).toBeTruthy();
+      return tmpFile;
+    });
+
+    // Check to make sure the file is closed
+    await expect(file.readFile()).rejects.toThrow(/file closed/);
+  });
+});

--- a/src/utils/tmpfile.ts
+++ b/src/utils/tmpfile.ts
@@ -1,0 +1,33 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+type TempFileHandler<T> = (file: fs.FileHandle) => Promise<T>;
+type TempDirHandler<T> = (dir: string) => Promise<T>;
+
+// Invokes the given handler with a handle to a temporary file. The file
+// is deleted after the handler returns.
+export const withTempFile = async <T>(
+  handler: TempFileHandler<T>
+): Promise<T> =>
+  withTempDir(async (dir) => {
+    const file = await fs.open(path.join(dir, 'tempfile'), 'w+');
+    try {
+      return await handler(file);
+    } finally {
+      file.close();
+    }
+  });
+
+// Invokes the given handler with a temporary directory. The directory is
+// deleted after the handler returns.
+const withTempDir = async <T>(handler: TempDirHandler<T>) => {
+  const tmpDir = await fs.realpath(os.tmpdir());
+  const dir = await fs.mkdtemp(tmpDir + path.sep);
+
+  try {
+    return await handler(dir);
+  } finally {
+    fs.rmdir(dir, { recursive: true });
+  }
+};


### PR DESCRIPTION
Adds a `withTempFile` utility function which passes a temporary file to the specified callback and then cleans-up after the callback exits.