### PR TITLE
add missing --provenance flag to publish command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install dependencies and build
         run: npm ci && npm run build
       - name: Publish package
-        run: npm exec npm@npm/cli#provenance -- publish
+        run: npm exec npm@npm/cli#provenance -- publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

The `--provenance` flag got lost in a previous refactor.