### PR TITLE
update npm CLI in publish workflow to @latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Install dependencies and build
         run: npm ci && npm run build
       - name: Publish package
-        run: npm exec npm@npm/cli#provenance -- publish --provenance
+        run: |
+          npm install -g npm@latest
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
Update publish workflow to use the @latest version of the npm CLI w/ the `--provenance` flag.