### PR TITLE
bootstrap changelogs for all of the packages

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,0 +1,13 @@
+# tuf-js
+
+## 1.1.0
+
+### Minor Changes
+
+- e67ae32: TUF metadata model classes refactored into dedicated @tufjs/models package
+
+## 1.0.0
+
+### Major Changes
+
+- 99624cc: Initial release

--- a/packages/models/CHANGELOG.md
+++ b/packages/models/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tufjs/models
+
+## 1.0.0
+
+### Major Changes
+
+- e67ae32: Initial release of dedicated models package

--- a/packages/repo-mock/CHANGELOG.md
+++ b/packages/repo-mock/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @tufjs/repo-mock
+
+## 1.0.0
+
+### Major Changes
+
+- e67ae32: Initial release


### PR DESCRIPTION
Normally, the `changeset` CLI would handle the maintenance of our `CHANGELOG.md` files but we had some errors during the initial run of the workflow which prevented them from being created. I'm manually bootstrapping the files here but we shouldn't have to make any manual edits to this going forward.