### PR TITLE
Replace missing TargetFile export in client pkg

### DIFF
--- a/.changeset/brown-kids-mate.md
+++ b/.changeset/brown-kids-mate.md
@@ -1,0 +1,5 @@
+---
+'tuf-js': patch
+---
+
+Re-add missing TargetFile export

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,2 +1,3 @@
+export { TargetFile } from '@tufjs/models';
 export { BaseFetcher, Fetcher } from './fetcher';
 export { Updater } from './updater';


### PR DESCRIPTION
This package-level export was lost as part of the refactoring and constitutes a breaking change to the public interface. This bugfix replaces the missing export.