### PR TITLE
run smoke tests on ubuntu and windows

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -10,7 +10,18 @@ on:
 jobs:
   fetch-target:
     name: Fetch Target From TUF Repo
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os: ubuntu-latest
+            shell: bash
+          - os: windows-latest
+            shell: cmd
+    runs-on: ${{ matrix.platform.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }}
     steps:
       - name: Checkout source
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3


### PR DESCRIPTION
Add test matrix to smoke test workflow to run tests on windows in addition to linux. Will hopefully help uncover any weird, platform-specific file system issues.