### PR TITLE
update repo-mock to init local tuf cache

### DIFF
--- a/.changeset/early-clocks-play.md
+++ b/.changeset/early-clocks-play.md
@@ -1,0 +1,5 @@
+---
+'@tufjs/repo-mock': minor
+---
+
+New function to set-up repo mock and initialize local cache

--- a/packages/repo-mock/src/__tests__/index.test.ts
+++ b/packages/repo-mock/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { Metadata, MetadataKind } from '@tufjs/models';
+import fs from 'fs';
 import http from 'http';
-import { clearMock, mockRepo } from '../index';
+import tufmock, { clearMock, mockRepo } from '../index';
 
 describe('mockRepo', () => {
   const baseURL = 'http://localhost:8000';
@@ -70,6 +71,31 @@ describe('mockRepo', () => {
 
     // Non-existent target
     await expect(fetch(`${baseURL}/targets/bar.txt`)).rejects.toThrow(/404/);
+  });
+});
+
+describe('default', () => {
+  const subject = tufmock([]);
+
+  it('creates a cache directory', () => {
+    expect(subject.cachePath).toBeTruthy();
+
+    const stat = fs.statSync(subject.cachePath);
+    expect(stat.isDirectory()).toBeTruthy();
+  });
+
+  it('inits the cache directory with the root metadata', () => {
+    const rootPath = `${subject.cachePath}/root.json`;
+    const stat = fs.statSync(rootPath);
+    expect(stat.isFile()).toBeTruthy();
+  });
+
+  describe('teardown', () => {
+    it('removes the cache directory', () => {
+      subject.teardown();
+
+      expect(() => fs.statSync(subject.cachePath)).toThrow();
+    });
   });
 });
 

--- a/packages/repo-mock/src/index.ts
+++ b/packages/repo-mock/src/index.ts
@@ -1,4 +1,7 @@
+import fs from 'fs';
 import nock from 'nock';
+import os from 'os';
+import path from 'path';
 import { KeyPair } from './key';
 import {
   createRootMeta,
@@ -6,11 +9,23 @@ import {
   createTargetsMeta,
   createTimestampMeta,
 } from './metadata';
-import { collectTargets, Target } from './target';
+import { Target, collectTargets } from './target';
 
 export type { Target } from './target';
 
-export function mockRepo(baseURL: string, targets: Target[]): string {
+interface MockRepoOptions {
+  baseURL?: string;
+  metadataPathPrefix?: string;
+  targetPathPrefix?: string;
+}
+
+export function mockRepo(
+  baseURL: string,
+  targets: Target[],
+  options: Omit<MockRepoOptions, 'baseURL'> = {}
+): string {
+  const metadataPrefix = options.metadataPathPrefix ?? '/metadata';
+  const targetPrefix = options.targetPathPrefix ?? '/targets';
   const keyPair = new KeyPair();
 
   // Translate the input targets into TUF TargetFile objects
@@ -22,15 +37,23 @@ export function mockRepo(baseURL: string, targets: Target[]): string {
   const timestampMeta = createTimestampMeta(snapshotMeta, keyPair);
   const rootMeta = createRootMeta(keyPair);
 
+  // Calculate paths for all of the metadata files
+  const rootPath = `${metadataPrefix}/1.root.json`;
+  const timestampPath = `${metadataPrefix}/timestamp.json`;
+  const snapshotPath = `${metadataPrefix}/snapshot.json`;
+  const targetsPath = `${metadataPrefix}/targets.json`;
+
   // Mock the metadata endpoints
-  nock(baseURL).get('/metadata/1.root.json').reply(200, rootMeta);
-  nock(baseURL).get('/metadata/timestamp.json').reply(200, timestampMeta);
-  nock(baseURL).get('/metadata/snapshot.json').reply(200, snapshotMeta);
-  nock(baseURL).get('/metadata/targets.json').reply(200, targetsMeta);
+  nock(baseURL).get(rootPath).reply(200, rootMeta);
+  nock(baseURL).get(timestampPath).reply(200, timestampMeta);
+  nock(baseURL).get(snapshotPath).reply(200, snapshotMeta);
+  nock(baseURL).get(targetsPath).reply(200, targetsMeta);
 
   // Mock the target endpoints
   targets.forEach((target) => {
-    nock(baseURL).get(`/targets/${target.name}`).reply(200, target.content);
+    nock(baseURL)
+      .get(`${targetPrefix}/${target.name}`)
+      .reply(200, target.content);
   });
 
   // Mock a 404 response for non-existent metadata/target files
@@ -42,3 +65,39 @@ export function mockRepo(baseURL: string, targets: Target[]): string {
 export function clearMock() {
   nock.cleanAll();
 }
+
+class Scope {
+  private readonly targets: Target[];
+  private readonly options: MockRepoOptions;
+  public readonly baseURL: string;
+  public readonly cachePath: string;
+
+  constructor(targets: Target[], options: MockRepoOptions = {}) {
+    this.targets = targets;
+    this.options = options;
+
+    this.baseURL =
+      options.baseURL ??
+      `http://${Math.random().toString(36).substring(2)}.com`;
+    this.cachePath = fs.mkdtempSync(path.join(os.tmpdir(), 'tuf-cache-test-'));
+    this.reset();
+  }
+
+  public reset() {
+    clearMock();
+    const rootJSON = mockRepo(this.baseURL, this.targets, this.options);
+    fs.writeFileSync(path.join(this.cachePath, 'root.json'), rootJSON);
+  }
+
+  public teardown() {
+    clearMock();
+    fs.rmSync(this.cachePath, { recursive: true });
+  }
+}
+
+export default (targets: Target | Target[], options: MockRepoOptions = {}) => {
+  if (!Array.isArray(targets)) {
+    targets = [targets];
+  }
+  return new Scope(targets, options);
+};


### PR DESCRIPTION
Updates the `@tufjs/repo-mock` library with a new helper function which will set-up the remote repo mock endpoints and also initialize the local TUF cache w/ the generated "root.json".

Also adds support for configurable prefixes for the remote metadata and target URLs.