### PR TITLE
revert minimatch dependency to version 7.4.6

### DIFF
--- a/.changeset/tender-mangos-work.md
+++ b/.changeset/tender-mangos-work.md
@@ -1,0 +1,5 @@
+---
+'@tufjs/models': patch
+---
+
+Revert to `minimatch@7.4.6`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5566,20 +5566,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/minimatch": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.3.tgz",
-      "integrity": "sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/minimist-options": {
       "version": "4.1.0",
       "dev": true,
@@ -7620,14 +7606,14 @@
     },
     "packages/client": {
       "name": "tuf-js",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "1.0.1",
+        "@tufjs/models": "1.0.2",
         "make-fetch-happen": "^11.0.1"
       },
       "devDependencies": {
-        "@tufjs/repo-mock": "1.0.1",
+        "@tufjs/repo-mock": "1.1.0",
         "@types/make-fetch-happen": "^10.0.1",
         "@types/node": "^18.15.11",
         "nock": "^13.2.9",
@@ -7639,11 +7625,11 @@
     },
     "packages/models": {
       "name": "@tufjs/models",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "1.0.0",
-        "minimatch": "^8.0.3"
+        "minimatch": "^7.4.6"
       },
       "devDependencies": {
         "@types/minimatch": "^5.1.2",
@@ -7654,12 +7640,26 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "packages/models/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/repo-mock": {
       "name": "@tufjs/repo-mock",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "1.0.1",
+        "@tufjs/models": "1.0.2",
         "nock": "^13.3.0"
       },
       "devDependencies": {
@@ -9049,14 +9049,24 @@
         "@tufjs/canonical-json": "1.0.0",
         "@types/minimatch": "^5.1.2",
         "@types/node": "^18.15.11",
-        "minimatch": "^8.0.3",
+        "minimatch": "^7.4.6",
         "typescript": "^5.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@tufjs/repo-mock": {
       "version": "file:packages/repo-mock",
       "requires": {
-        "@tufjs/models": "1.0.1",
+        "@tufjs/models": "1.0.2",
         "@types/node": "^18.15.11",
         "nock": "^13.3.0",
         "typescript": "^5.0.4"
@@ -11516,14 +11526,6 @@
       "version": "1.0.1",
       "dev": true
     },
-    "minimatch": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.3.tgz",
-      "integrity": "sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==",
-      "requires": {
-        "brace-expansion": "^2.0.1"
-      }
-    },
     "minimist-options": {
       "version": "4.1.0",
       "dev": true,
@@ -12596,8 +12598,8 @@
     "tuf-js": {
       "version": "file:packages/client",
       "requires": {
-        "@tufjs/models": "1.0.1",
-        "@tufjs/repo-mock": "1.0.1",
+        "@tufjs/models": "1.0.2",
+        "@tufjs/repo-mock": "1.1.0",
         "@types/make-fetch-happen": "^10.0.1",
         "@types/node": "^18.15.11",
         "make-fetch-happen": "^11.0.1",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "minimatch": "^8.0.3",
+    "minimatch": "^7.4.6",
     "@tufjs/canonical-json": "1.0.0"
   },
   "engines": {


### PR DESCRIPTION
This keeps us in sync w/ the npm cli version of this package