### PR TITLE
add cachePath config option for repo mock

### DIFF
--- a/.changeset/silver-rings-brush.md
+++ b/.changeset/silver-rings-brush.md
@@ -1,0 +1,5 @@
+---
+'@tufjs/repo-mock': minor
+---
+
+Support configurable `cachePath` when bootstrapping mocked TUF repository


### PR DESCRIPTION
Updates the `repo-mock` package with a new `cachePath` configuration option which can be used to specify a location for the cached TUF metadata/target files when working with a mocked repository.