### PR TITLE
add responseCount config option for repo mock

### DIFF
--- a/.changeset/gentle-hats-end.md
+++ b/.changeset/gentle-hats-end.md
@@ -1,0 +1,5 @@
+---
+'@tufjs/repo-mock': minor
+---
+
+Support configurable `responseCount` for mocked TUF metadata endpoints

--- a/packages/repo-mock/src/__tests__/index.test.ts
+++ b/packages/repo-mock/src/__tests__/index.test.ts
@@ -18,10 +18,10 @@ describe('mockRepo', () => {
   });
 
   it('mocks the metadata endpoints', async () => {
-    mockRepo(baseURL, []);
+    // Set-up mock and retrieve root
+    const rootJSON = mockRepo(baseURL, []);
+    expect(rootJSON).toBeTruthy();
 
-    // Retrieve the root metadata file
-    const rootJSON = await fetch(`${baseURL}/metadata/1.root.json`);
     const rootMeta = Metadata.fromJSON(MetadataKind.Root, JSON.parse(rootJSON));
     expect(rootMeta).toBeTruthy();
     expect(() => rootMeta.verifyDelegate('root', rootMeta)).not.toThrow();
@@ -68,9 +68,6 @@ describe('mockRepo', () => {
     mockRepo(baseURL, [targetFile]);
     const target = await fetch(`${baseURL}/targets/foo.txt`);
     expect(target).toEqual(targetFile.content);
-
-    // Non-existent target
-    await expect(fetch(`${baseURL}/targets/bar.txt`)).rejects.toThrow(/404/);
   });
 });
 


### PR DESCRIPTION
Add support for `responseCount` config option to control how many responses each of the metadata mock endpoints should return.

Also removes mocks for requests which should not occur. This resolves issues where we were leaving unfulfilled mocks at the end of some tests.