### PR TITLE
update minimatch dependency to 9.0.0

### DIFF
--- a/.changeset/tasty-islands-learn.md
+++ b/.changeset/tasty-islands-learn.md
@@ -1,0 +1,5 @@
+---
+'@tufjs/models': patch
+---
+
+Update to `minimatch@9.0.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5571,6 +5571,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist-options": {
       "version": "4.1.0",
       "dev": true,
@@ -7619,7 +7633,7 @@
         "make-fetch-happen": "^11.1.0"
       },
       "devDependencies": {
-        "@tufjs/repo-mock": "1.2.0",
+        "@tufjs/repo-mock": "1.3.0",
         "@types/make-fetch-happen": "^10.0.1",
         "@types/node": "^18.16.3",
         "nock": "^13.3.1",
@@ -7635,7 +7649,7 @@
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "1.0.0",
-        "minimatch": "^7.4.6"
+        "minimatch": "^9.0.0"
       },
       "devDependencies": {
         "@types/minimatch": "^5.1.2",
@@ -7646,23 +7660,9 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "packages/models/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "packages/repo-mock": {
       "name": "@tufjs/repo-mock",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@tufjs/models": "1.0.3",
@@ -9055,18 +9055,8 @@
         "@tufjs/canonical-json": "1.0.0",
         "@types/minimatch": "^5.1.2",
         "@types/node": "^18.16.3",
-        "minimatch": "^7.4.6",
+        "minimatch": "^9.0.0",
         "typescript": "^5.0.4"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
       }
     },
     "@tufjs/repo-mock": {
@@ -11536,6 +11526,14 @@
       "version": "1.0.1",
       "dev": true
     },
+    "minimatch": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "requires": {
+        "brace-expansion": "^2.0.1"
+      }
+    },
     "minimist-options": {
       "version": "4.1.0",
       "dev": true,
@@ -12611,7 +12609,7 @@
       "version": "file:packages/client",
       "requires": {
         "@tufjs/models": "1.0.3",
-        "@tufjs/repo-mock": "1.2.0",
+        "@tufjs/repo-mock": "1.3.0",
         "@types/make-fetch-happen": "^10.0.1",
         "@types/node": "^18.16.3",
         "make-fetch-happen": "^11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2031,11 +2031,6 @@
         "@types/ssri": "*"
       }
     },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
       "dev": true,
@@ -7652,7 +7647,6 @@
         "minimatch": "^9.0.0"
       },
       "devDependencies": {
-        "@types/minimatch": "^5.1.2",
         "@types/node": "^18.16.3",
         "typescript": "^5.0.4"
       },
@@ -9053,7 +9047,6 @@
       "version": "file:packages/models",
       "requires": {
         "@tufjs/canonical-json": "1.0.0",
-        "@types/minimatch": "^5.1.2",
         "@types/node": "^18.16.3",
         "minimatch": "^9.0.0",
         "typescript": "^5.0.4"
@@ -9165,10 +9158,6 @@
         "@types/retry": "*",
         "@types/ssri": "*"
       }
-    },
-    "@types/minimatch": {
-      "version": "5.1.2",
-      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.2",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "minimatch": "^7.4.6",
+    "minimatch": "^9.0.0",
     "@tufjs/canonical-json": "1.0.0"
   },
   "engines": {

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -28,13 +28,12 @@
   },
   "homepage": "https://github.com/theupdateframework/tuf-js/tree/main/packages/models#readme",
   "devDependencies": {
-    "@types/minimatch": "^5.1.2",
     "@types/node": "^18.16.3",
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "minimatch": "^9.0.0",
-    "@tufjs/canonical-json": "1.0.0"
+    "@tufjs/canonical-json": "1.0.0",
+    "minimatch": "^9.0.0"
   },
   "engines": {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0"

--- a/packages/models/src/role.ts
+++ b/packages/models/src/role.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 import util from 'util';
 import { ValueError } from './error';
 import { guard, JSONObject, JSONValue } from './utils';


### PR DESCRIPTION
Updates the `minimatch` dependency in the `@tufjs/models` package to `9.0.0`.

The only change here is the move from a default to a named export.

Also removes the `@types/minimatch` package given that `minimatch` now has embedded types.