### PR TITLE
set-up debug logging

### DIFF
--- a/.changeset/flat-kiwis-mix.md
+++ b/.changeset/flat-kiwis-mix.md
@@ -1,0 +1,5 @@
+---
+'tuf-js': patch
+---
+
+Integrate `debug` logging library

--- a/package-lock.json
+++ b/package-lock.json
@@ -1967,6 +1967,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -2035,6 +2044,12 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "20.1.1",
@@ -3015,7 +3030,8 @@
     },
     "node_modules/debug": {
       "version": "4.3.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -7625,10 +7641,12 @@
       "license": "MIT",
       "dependencies": {
         "@tufjs/models": "1.0.4",
+        "debug": "^4.3.4",
         "make-fetch-happen": "^11.1.0"
       },
       "devDependencies": {
         "@tufjs/repo-mock": "1.3.1",
+        "@types/debug": "^4.1.7",
         "@types/make-fetch-happen": "^10.0.1",
         "@types/node": "^20.1.1",
         "nock": "^13.3.1",
@@ -9100,6 +9118,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -9161,6 +9188,12 @@
     },
     "@types/minimist": {
       "version": "1.2.2",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -9799,6 +9832,8 @@
     },
     "debug": {
       "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -12599,8 +12634,10 @@
       "requires": {
         "@tufjs/models": "1.0.4",
         "@tufjs/repo-mock": "1.3.1",
+        "@types/debug": "*",
         "@types/make-fetch-happen": "^10.0.1",
         "@types/node": "^20.1.1",
+        "debug": "^4.3.4",
         "make-fetch-happen": "^11.1.0",
         "nock": "^13.3.1",
         "typescript": "^5.0.4"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,14 +29,16 @@
   "homepage": "https://github.com/theupdateframework/tuf-js/tree/main/packages/client#readme",
   "devDependencies": {
     "@tufjs/repo-mock": "1.3.1",
+    "@types/debug": "^4.1.7",
     "@types/make-fetch-happen": "^10.0.1",
     "@types/node": "^20.1.1",
     "nock": "^13.3.1",
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "make-fetch-happen": "^11.1.0",
-    "@tufjs/models": "1.0.4"
+    "@tufjs/models": "1.0.4",
+    "debug": "^4.3.4",
+    "make-fetch-happen": "^11.1.0"
   },
   "engines": {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0"

--- a/packages/client/src/fetcher.ts
+++ b/packages/client/src/fetcher.ts
@@ -1,9 +1,12 @@
+import debug from 'debug';
 import fs from 'fs';
 import fetch from 'make-fetch-happen';
 import util from 'util';
 
 import { DownloadHTTPError, DownloadLengthMismatchError } from './error';
 import { withTempFile } from './utils/tmpfile';
+
+const log = debug('tuf:fetch');
 
 type DownloadFileHandler<T> = (file: string) => Promise<T>;
 
@@ -87,6 +90,7 @@ export class DefaultFetcher extends BaseFetcher {
   }
 
   public override async fetch(url: string): Promise<NodeJS.ReadableStream> {
+    log('GET %s', url);
     const response = await fetch(url, {
       timeout: this.timeout,
       retry: this.retries,

--- a/packages/client/src/updater.ts
+++ b/packages/client/src/updater.ts
@@ -1,4 +1,5 @@
 import { Metadata, MetadataKind, TargetFile, Targets } from '@tufjs/models';
+import debug from 'debug';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Config, defaultConfig } from './config';
@@ -20,6 +21,8 @@ export interface UpdaterOptions {
   fetcher?: Fetcher;
   config?: Partial<Config>;
 }
+
+const log = debug('tuf:cache');
 
 interface Delegation {
   roleName: string;
@@ -118,6 +121,7 @@ export class Updater {
         await targetInfo.verify(fs.createReadStream(fileName));
 
         // Copy file to target path
+        log('WRITE %s', targetPath);
         fs.copyFileSync(fileName, targetPath);
       }
     );
@@ -146,6 +150,7 @@ export class Updater {
 
   private loadLocalMetadata(fileName: string): Buffer {
     const filePath = path.join(this.dir, `${fileName}.json`);
+    log('READ %s', filePath);
     return fs.readFileSync(filePath);
   }
 
@@ -400,6 +405,7 @@ export class Updater {
   private async persistMetadata(metaDataName: string, bytesData: Buffer) {
     try {
       const filePath = path.join(this.dir, `${metaDataName}.json`);
+      log('WRITE %s', filePath);
       fs.writeFileSync(filePath, bytesData.toString('utf8'));
     } catch (error) {
       throw new PersistError(


### PR DESCRIPTION
Sets-up debug logging for all fetch and cache read/write operations. By default, no logging output will be displayed, but if you enable logging through the `DEBUG` environment variable you'll see something like this:

<img width="889" alt="image" src="https://github.com/theupdateframework/tuf-js/assets/398027/b709cc36-2d69-4546-94e3-6146ef6da9b1">

Note that the `debug` package is already a dependency of `make-fetch-happen` so this does not introduce any new package dependencies.
