### PR TITLE
Deprecate `retries` config opt in favor of `retry`

### DIFF
--- a/.changeset/heavy-chairs-wash.md
+++ b/.changeset/heavy-chairs-wash.md
@@ -1,0 +1,5 @@
+---
+'tuf-js': minor
+---
+
+Deprecates in `fetchRetries` config option in the `UpdaterOptions` interface in favor of the new `fetchRetry` option.

--- a/packages/client/src/__tests__/updater.test.ts
+++ b/packages/client/src/__tests__/updater.test.ts
@@ -21,7 +21,7 @@ describe('Updater', () => {
     metadataBaseUrl: `${baseURL}/metadata`,
     targetBaseUrl: `${baseURL}/targets`,
     config: {
-      fetchRetries: 0,
+      fetchRetry: 0,
       fetchTimeout: 1000,
     },
   };

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,4 +1,20 @@
-export const defaultConfig = {
+import type { MakeFetchHappenOptions } from 'make-fetch-happen';
+
+export type Config = {
+  maxRootRotations: number;
+  maxDelegations: number;
+  rootMaxLength: number;
+  timestampMaxLength: number;
+  snapshotMaxLength: number;
+  targetsMaxLength: number;
+  prefixTargetsWithHash: boolean;
+  fetchTimeout: number;
+  // deprecated use fetchRetry instead
+  fetchRetries: number | undefined;
+  fetchRetry: MakeFetchHappenOptions['retry'];
+};
+
+export const defaultConfig: Config = {
   maxRootRotations: 32,
   maxDelegations: 32,
   rootMaxLength: 512000, //bytes
@@ -7,7 +23,6 @@ export const defaultConfig = {
   targetsMaxLength: 5000000, // bytes
   prefixTargetsWithHash: true,
   fetchTimeout: 100000, // milliseconds
-  fetchRetries: 2,
+  fetchRetries: undefined,
+  fetchRetry: 2,
 };
-
-export type Config = typeof defaultConfig;

--- a/packages/client/src/fetcher.ts
+++ b/packages/client/src/fetcher.ts
@@ -6,6 +6,8 @@ import util from 'util';
 import { DownloadHTTPError, DownloadLengthMismatchError } from './error';
 import { withTempFile } from './utils/tmpfile';
 
+import type { MakeFetchHappenOptions } from 'make-fetch-happen';
+
 const log = debug('tuf:fetch');
 
 type DownloadFileHandler<T> = (file: string) => Promise<T>;
@@ -74,26 +76,28 @@ export abstract class BaseFetcher implements Fetcher {
   }
 }
 
+type Retry = MakeFetchHappenOptions['retry'];
+
 interface FetcherOptions {
   timeout?: number;
-  retries?: number;
+  retry?: Retry;
 }
 
 export class DefaultFetcher extends BaseFetcher {
   private timeout?: number;
-  private retries?: number;
+  private retry?: Retry;
 
   constructor(options: FetcherOptions = {}) {
     super();
     this.timeout = options.timeout;
-    this.retries = options.retries;
+    this.retry = options.retry;
   }
 
   public override async fetch(url: string): Promise<NodeJS.ReadableStream> {
     log('GET %s', url);
     const response = await fetch(url, {
       timeout: this.timeout,
-      retry: this.retries,
+      retry: this.retry,
     });
 
     if (!response.ok || !response?.body) {

--- a/packages/client/src/updater.ts
+++ b/packages/client/src/updater.ts
@@ -62,7 +62,7 @@ export class Updater {
       fetcher ||
       new DefaultFetcher({
         timeout: this.config.fetchTimeout,
-        retries: this.config.fetchRetries,
+        retry: this.config.fetchRetries ?? this.config.fetchRetry,
       });
   }
 


### PR DESCRIPTION
Updates the `Config` type (exposed via the `UpdaterOptions` interface) to have a new `fetchRetry` option which supersedes the `fetchRetries` option. 

Whereas `fetchRetries` only accepted a numeric value (the number of times to retry the request), `fetchRetry` accepts all of the [options](https://github.com/tim-kos/node-retry#retrytimeoutsoptions) supported by the [retry](https://www.npmjs.com/package/retry) library which allows for more sophisticated strategies like exponential back-off.

Setting `fetchRetry` is still supported, but this option may be removed in a future release.