### PR TITLE
export missing types from tuf-js pkg

### DIFF
--- a/.changeset/clever-dolls-boil.md
+++ b/.changeset/clever-dolls-boil.md
@@ -1,0 +1,5 @@
+---
+'tuf-js': minor
+---
+
+Export `UpdaterOptions` and `Config` types

--- a/packages/client/src/__tests__/index.test.ts
+++ b/packages/client/src/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import * as tuf from '..';
+
+it('exports classes', () => {
+  expect(tuf.BaseFetcher).toBeInstanceOf(Function);
+  expect(tuf.TargetFile).toBeInstanceOf(Function);
+  expect(tuf.Updater).toBeInstanceOf(Function);
+});
+
+it('exports types', () => {
+  const config: Partial<tuf.Config> = {};
+  expect(config).toBeDefined();
+
+  const fetcher: Partial<tuf.Fetcher> = {};
+  expect(fetcher).toBeDefined();
+
+  const updaterOpts: Partial<tuf.UpdaterOptions> = {};
+  expect(updaterOpts).toBeDefined();
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,3 +1,5 @@
 export { TargetFile } from '@tufjs/models';
 export { BaseFetcher, Fetcher } from './fetcher';
-export { Updater } from './updater';
+export { Updater, UpdaterOptions } from './updater';
+
+export type { Config } from './config';


### PR DESCRIPTION
Exports the `UpdaterOptions` and `Config` types used by the `Updater`.

Previously, you had to go through some weird contortions to get ahold of the `Config` type:

```typescript
const config: ConstructorParameters<typeof Updater>[0]['config'] = {
  fetchTimeout: 5000,
};
```

Now consumers can simply do:

```typescript
const config: Config = {
  fetchTimeout: 5000,
};
```