### PR TITLE
update maxRootRotation to 256

### DIFF
--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -15,7 +15,7 @@ export type Config = {
 };
 
 export const defaultConfig: Config = {
-  maxRootRotations: 32,
+  maxRootRotations: 256,
   maxDelegations: 32,
   rootMaxLength: 512000, //bytes
   timestampMaxLength: 16384, // bytes

--- a/packages/client/src/updater.ts
+++ b/packages/client/src/updater.ts
@@ -185,7 +185,7 @@ export class Updater {
     const lowerBound = rootVersion + 1;
     const upperBound = lowerBound + this.config.maxRootRotations;
 
-    for (let version = lowerBound; version <= upperBound; version++) {
+    for (let version = lowerBound; version < upperBound; version++) {
       const rootUrl = url.join(this.metadataBaseUrl, `${version}.root.json`);
       try {
         // Client workflow 5.3.3: download new root metadata file


### PR DESCRIPTION
per https://github.com/theupdateframework/python-tuf/issues/2672


this configuration variable controls how many root versions the client will upgrade in a single refresh(). The idea is to prevent a malicious repository from filling the disk with root versions.

We want a number that is high enough that a repository should not have made that many roots in the time that clients take to update the "embedded" root that the client shipped with.

32 is small enough that a repository could possibly reach it while clients with v1 embedded in them are still in use. Let's bump to 256: this should be plenty.