### PR TITLE
raise error on root metadata error

### DIFF
--- a/.changeset/curvy-ducks-cross.md
+++ b/.changeset/curvy-ducks-cross.md
@@ -1,0 +1,5 @@
+---
+'tuf-js': patch
+---
+
+Ensure errors are thrown when root metadata is invalid

--- a/packages/client/src/updater.ts
+++ b/packages/client/src/updater.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Config, defaultConfig } from './config';
 import {
+  DownloadHTTPError,
   EqualVersionError,
   PersistError,
   RuntimeError,
@@ -200,7 +201,14 @@ export class Updater {
         // Client workflow 5.3.8: persist root metadata file
         this.persistMetadata(MetadataKind.Root, bytesData);
       } catch (error) {
-        break;
+        if (error instanceof DownloadHTTPError) {
+          //  404/403 means current root is newest available
+          if ([403, 404].includes(error.statusCode)) {
+            break;
+          }
+        }
+
+        throw error;
       }
     }
   }


### PR DESCRIPTION
Updates the `loadRoot` method in the `Updater` to ensure that any errors encountered when processing the root metadata are raised to the calling application. Previously, the method would silently ignore errors making it difficult for the client to properly recover from any situation where the remote repository was serving invalid data.

The only error which should be ignored is a 404 or 403 error which indicates that the client already has the latest root metadata. Any other error should be raised to the calling application.

Fixes #778 