### PR TITLE
reject duplicate keyids in signatures list

### DIFF
--- a/.changeset/clever-cobras-hang.md
+++ b/.changeset/clever-cobras-hang.md
@@ -1,0 +1,5 @@
+---
+'@tufjs/models': patch
+---
+
+Raise an error if duplicate key IDs found in metadata signature list

--- a/packages/models/src/__tests__/metadata.test.ts
+++ b/packages/models/src/__tests__/metadata.test.ts
@@ -1,4 +1,4 @@
-import { Metadata, Root, Signature } from '../index';
+import { Metadata, MetadataKind, Root, Signature, ValueError } from '../index';
 
 describe('Metadata', () => {
   describe('#sign', () => {
@@ -46,6 +46,94 @@ describe('Metadata', () => {
 
         expect(subject.signatures).toHaveProperty(sig2.keyID);
         expect(subject.signatures[sig2.keyID]).toEqual(sig2);
+      });
+    });
+  });
+
+  describe('#fromJSON', () => {
+    const json = {
+      signatures: [
+        {
+          keyid: 'foo',
+          sig: 'DEAD',
+        },
+      ],
+      signed: {
+        _type: 'root',
+        version: 1,
+        spec_version: '1.0.0',
+        expires: '2020-01-01T00:00:00.000Z',
+        consistent_snapshot: false,
+        keys: {
+          abc: {
+            keyid_hash_algorithms: ['sha256', 'sha512'],
+            keytype: 'ed25519',
+            keyval: {
+              public: 'foo',
+            },
+            scheme: 'ed25519',
+          },
+        },
+        roles: {
+          root: { keyids: ['xyz'], threshold: 1 },
+          timestamp: { keyids: [], threshold: 1 },
+          snapshot: { keyids: [], threshold: 1 },
+          targets: { keyids: [], threshold: 1 },
+        },
+      },
+    };
+
+    describe('when the JSON is valid', () => {
+      it('returns the expected Metadata', () => {
+        const root = Metadata.fromJSON(MetadataKind.Root, json);
+
+        expect(root.signatures).toHaveProperty('foo');
+        expect(root.signed).toBeDefined();
+        expect(root.signed.type).toEqual(MetadataKind.Root);
+      });
+    });
+
+    describe('when the JSON contains duplicate signatures', () => {
+      it('returns the expected Metadata', () => {
+        expect(() => {
+          Metadata.fromJSON(MetadataKind.Root, {
+            ...json,
+            signatures: [json.signatures[0], json.signatures[0]],
+          });
+        }).toThrow(ValueError);
+      });
+    });
+
+    describe('when the JSON is missing the signed element', () => {
+      it('returns the expected Metadata', () => {
+        expect(() => {
+          Metadata.fromJSON(MetadataKind.Root, {
+            ...json,
+            signed: '',
+          });
+        }).toThrow(TypeError);
+      });
+    });
+
+    describe('when the JSON is contains an unknown metadata type', () => {
+      it('returns the expected Metadata', () => {
+        expect(() => {
+          Metadata.fromJSON(MetadataKind.Root, {
+            ...json,
+            signed: { ...json.signed, _type: 'foo' },
+          });
+        }).toThrow(ValueError);
+      });
+    });
+
+    describe('when the JSON is contains signatures which are not an array', () => {
+      it('returns the expected Metadata', () => {
+        expect(() => {
+          Metadata.fromJSON(MetadataKind.Root, {
+            ...json,
+            signatures: 'foo',
+          });
+        }).toThrow(TypeError);
       });
     });
   });


### PR DESCRIPTION
Previously, when the duplicate keyids were found in the metadata signatures list they would be silently de-duped (dropping the duplicate entries). With this change, an error will be raised if duplicate keyids are found.

Fixes #780 