### PR TITLE
ensure role name properly encoded

### DIFF
--- a/.changeset/quick-boxes-move.md
+++ b/.changeset/quick-boxes-move.md
@@ -1,0 +1,5 @@
+---
+'tuf-js': patch
+---
+
+Ensure that role names are properly encoded when used in URLs or file names

--- a/packages/client/src/updater.ts
+++ b/packages/client/src/updater.ts
@@ -323,9 +323,10 @@ export class Updater {
         ? metaInfo.version
         : undefined;
 
+      const encodedRole = encodeURIComponent(role);
       const metadataUrl = url.join(
         this.metadataBaseUrl,
-        version ? `${version}.${role}.json` : `${role}.json`
+        version ? `${version}.${encodedRole}.json` : `${encodedRole}.json`
       );
 
       try {
@@ -431,13 +432,14 @@ export class Updater {
   }
 
   private persistMetadata(metaDataName: string, bytesData: Buffer) {
+    const encodedName = encodeURIComponent(metaDataName);
     try {
-      const filePath = path.join(this.dir, `${metaDataName}.json`);
+      const filePath = path.join(this.dir, `${encodedName}.json`);
       log('WRITE %s', filePath);
       fs.writeFileSync(filePath, bytesData.toString('utf8'));
     } catch (error) {
       throw new PersistError(
-        `Failed to persist metadata ${metaDataName} error: ${error}`
+        `Failed to persist metadata ${encodedName} error: ${error}`
       );
     }
   }


### PR DESCRIPTION
When dealing with custom role names, this change ensures that any special characters in the name are properly encoded before attempting to retrieve the role metadata from the remote repository or persisting it to the local metadata cache.

This will avoid errors if we encounter role names like `?`, `#`, or `../myunusualrole`.

Fixes #782 