### PR TITLE
feat!: replace `make-fetch-happen` with `globalThis.fetch`

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,13 +29,11 @@
   "homepage": "https://github.com/theupdateframework/tuf-js/tree/main/packages/client#readme",
   "devDependencies": {
     "@tufjs/repo-mock": "3.0.1",
-    "@types/debug": "^4.1.12",
-    "@types/make-fetch-happen": "^10.0.4"
+    "@types/debug": "^4.1.12"
   },
   "dependencies": {
     "@tufjs/models": "3.0.1",
-    "debug": "^4.3.6",
-    "make-fetch-happen": "^14.0.2"
+    "debug": "^4.3.6"
   },
   "engines": {
     "node": "^18.17.0 || >=20.5.0"

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,5 +1,3 @@
-import type { MakeFetchHappenOptions } from 'make-fetch-happen';
-
 export type Config = {
   maxRootRotations: number;
   maxDelegations: number;
@@ -9,9 +7,6 @@ export type Config = {
   targetsMaxLength: number;
   prefixTargetsWithHash: boolean;
   fetchTimeout: number;
-  // deprecated use fetchRetry instead
-  fetchRetries: number | undefined;
-  fetchRetry: MakeFetchHappenOptions['retry'];
 };
 
 export const defaultConfig: Config = {
@@ -23,6 +18,4 @@ export const defaultConfig: Config = {
   targetsMaxLength: 5000000, // bytes
   prefixTargetsWithHash: true,
   fetchTimeout: 100000, // milliseconds
-  fetchRetries: undefined,
-  fetchRetry: 2,
 };

--- a/packages/client/src/fetcher.ts
+++ b/packages/client/src/fetcher.ts
@@ -1,12 +1,10 @@
 import debug from 'debug';
 import fs from 'fs';
-import fetch from 'make-fetch-happen';
+import stream from 'stream';
 import util from 'util';
 
 import { DownloadHTTPError, DownloadLengthMismatchError } from './error';
 import { withTempFile } from './utils/tmpfile';
-
-import type { MakeFetchHappenOptions } from 'make-fetch-happen';
 
 const log = debug('tuf:fetch');
 
@@ -77,35 +75,29 @@ export abstract class BaseFetcher implements Fetcher {
   }
 }
 
-type Retry = MakeFetchHappenOptions['retry'];
-
 interface FetcherOptions {
   timeout?: number;
-  retry?: Retry;
 }
 
 export class DefaultFetcher extends BaseFetcher {
   private timeout?: number;
-  private retry?: Retry;
 
   constructor(options: FetcherOptions = {}) {
     super();
     this.timeout = options.timeout;
-    this.retry = options.retry;
   }
 
   public override async fetch(url: string): Promise<NodeJS.ReadableStream> {
     log('GET %s', url);
     const response = await fetch(url, {
-      timeout: this.timeout,
-      retry: this.retry,
+      signal: this.timeout && AbortSignal.timeout(this.timeout),
     });
 
     if (!response.ok || !response?.body) {
       throw new DownloadHTTPError('Failed to download', response.status);
     }
 
-    return response.body;
+    return stream.Readable.fromWeb(response.body);
   }
 }
 

--- a/packages/client/src/updater.ts
+++ b/packages/client/src/updater.ts
@@ -66,7 +66,6 @@ export class Updater {
       fetcher ||
       new DefaultFetcher({
         timeout: this.config.fetchTimeout,
-        retry: this.config.fetchRetries ?? this.config.fetchRetry,
       });
   }
 

--- a/packages/client/tests/updater.test.ts
+++ b/packages/client/tests/updater.test.ts
@@ -21,7 +21,6 @@ describe('Updater', () => {
     metadataBaseUrl: `${baseURL}/metadata`,
     targetBaseUrl: `${baseURL}/targets`,
     config: {
-      fetchRetry: 0,
       fetchTimeout: 1000,
     },
   };


### PR DESCRIPTION
This would allow shaving 1.2 MiB in the bundle size. This also removes the retry mecanism, which doesn't exist in WHATWG Fetch, but IMO that's worth it.