### PR TITLE
Bump tuf-conformance from 2.2.0 to 2.3.0

### DIFF
--- a/.github/scripts/tuf-conformance.xfails
+++ b/.github/scripts/tuf-conformance.xfails
@@ -1,0 +1,1 @@
+test_artifact_cache

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,6 +32,6 @@ jobs:
         run: npm run build
 
       - name: Run conformance suite
-        uses: theupdateframework/tuf-conformance@dee4e23533d7a12a6394d96b59b3ea0aa940f9bf # v2.2.0
+        uses: theupdateframework/tuf-conformance@9bfc222a371e30ad5511eb17449f68f855fb9d8f # v2.3.0
         with:
           entrypoint: ".github/scripts/tuf-conformance"


### PR DESCRIPTION
Updates the `theupdateframework/tuf-conformance` action to version 2.3.0

Skipping the [`test_artifact_cache`](https://github.com/theupdateframework/tuf-conformance/pull/260) test as this is not implemented in tuf-js.