### PR TITLE
Add custom user agent for fetch calls

### DIFF
--- a/.changeset/small-trams-own.md
+++ b/.changeset/small-trams-own.md
@@ -1,0 +1,5 @@
+---
+'tuf-js': minor
+---
+
+Support for custom user agent string on fetch calls

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -12,6 +12,7 @@ export type Config = {
   // deprecated use fetchRetry instead
   fetchRetries: number | undefined;
   fetchRetry: MakeFetchHappenOptions['retry'];
+  userAgent?: string;
 };
 
 export const defaultConfig: Config = {
@@ -25,4 +26,5 @@ export const defaultConfig: Config = {
   fetchTimeout: 100000, // milliseconds
   fetchRetries: undefined,
   fetchRetry: 2,
+  userAgent: '',
 };

--- a/packages/client/src/fetcher.ts
+++ b/packages/client/src/fetcher.ts
@@ -10,6 +10,8 @@ import type { MakeFetchHappenOptions } from 'make-fetch-happen';
 
 const log = debug('tuf:fetch');
 
+const USER_AGENT_HEADER = 'User-Agent';
+
 type DownloadFileHandler<T> = (file: string) => Promise<T>;
 
 export interface Fetcher {
@@ -79,16 +81,19 @@ export abstract class BaseFetcher implements Fetcher {
 type Retry = MakeFetchHappenOptions['retry'];
 
 interface FetcherOptions {
+  userAgent?: string;
   timeout?: number;
   retry?: Retry;
 }
 
 export class DefaultFetcher extends BaseFetcher {
+  private userAgent?: string;
   private timeout?: number;
   private retry?: Retry;
 
   constructor(options: FetcherOptions = {}) {
     super();
+    this.userAgent = options.userAgent;
     this.timeout = options.timeout;
     this.retry = options.retry;
   }
@@ -96,6 +101,9 @@ export class DefaultFetcher extends BaseFetcher {
   public override async fetch(url: string): Promise<NodeJS.ReadableStream> {
     log('GET %s', url);
     const response = await fetch(url, {
+      headers: {
+        [USER_AGENT_HEADER]: this.userAgent || '',
+      },
       timeout: this.timeout,
       retry: this.retry,
     });

--- a/packages/client/src/updater.ts
+++ b/packages/client/src/updater.ts
@@ -2,6 +2,7 @@ import { Metadata, MetadataKind, TargetFile, Targets } from '@tufjs/models';
 import debug from 'debug';
 import * as fs from 'fs';
 import * as path from 'path';
+import { version } from '../package.json';
 import { Config, defaultConfig } from './config';
 import {
   DownloadHTTPError,
@@ -62,9 +63,14 @@ export class Updater {
 
     this.trustedSet = new TrustedMetadataStore(data);
     this.config = { ...defaultConfig, ...config };
+    const userAgent = config?.userAgent
+      ? `${config.userAgent} tuf-js/${version}`
+      : `tuf-js/${version}`;
+
     this.fetcher =
       fetcher ||
       new DefaultFetcher({
+        userAgent,
         timeout: this.config.fetchTimeout,
         retry: this.config.fetchRetries ?? this.config.fetchRetry,
       });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noUnusedParameters": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Closes #681 

Adds a custom user agent to all fetch calls which identifies the specific version of the client. Also allows the user to augment the user agent string with a custom identifier.