### PR TITLE
Use node 24 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,9 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v3
         with:
-          node-version: 22
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
           cache: npm
-
-      - name: Install npm w/ OIDC support
-        run: |
-          npm install -g npm@^11.5.0
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This pull request updates the Node.js version used in the GitHub Actions release workflow and removes a step related to npm installation.